### PR TITLE
Fix type errors and warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
-**Changed**
+**Added**
 - `Forge#forge` (and all proxy methods) now accept an optional block, yielding the forged object to do user-defined post-processing.
+
+**Changed**
+- [Breaking] `Forge#forge` no longer accepts array of traits and hash of overrides as positional arguments.
 
 [Compare v0.1.0...main](https://github.com/trinistr/object_forge/compare/v0.1.0...main)
 

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -6,6 +6,7 @@ require "bundler/setup"
 
 # Load supporting libraries
 require "fileutils"
+require "time"
 
 require "benchmark"
 require "benchmark/ips"
@@ -31,6 +32,9 @@ FORGE =
 
 # Run benchmark
 FileUtils.mkdir_p("tmp")
+report_path = "tmp/benchmark #{Time.now.iso8601} " \
+              "(#{`ruby -v`.chomp}) " \
+              "(commit #{`git rev-parse HEAD`.chomp[0..7]}).json"
 StackProf.run(mode: :cpu, raw: true, out: "tmp/stackprof.dump") do
   Benchmark.ips do |ips|
     ips.report("yard.forge()") { FORGEYARD.forge(:foobar) }
@@ -44,9 +48,12 @@ StackProf.run(mode: :cpu, raw: true, out: "tmp/stackprof.dump") do
 
     ips.report("yard.forge(foo: 1, bar: 2)") { FORGEYARD.forge(:foobar, foo: 1, bar: 2) }
     ips.report("forge.forge(foo: 1, bar: 2)") { FORGE.forge(foo: 1, bar: 2) }
+
+    ips.json!(report_path)
   end
 end
+puts "Report saved to #{report_path}"
 
 # Generate flamegraph to actually understand StackProf's report
 `stackprof tmp/stackprof.dump --d3-flamegraph > tmp/flamegraph.html`
-puts "Flamegraph generated at tmp/flamegraph.html"
+puts "Flamegraph saved to tmp/flamegraph.html"

--- a/lib/object_forge/forge.rb
+++ b/lib/object_forge/forge.rb
@@ -75,12 +75,8 @@ module ObjectForge
     # @yieldreturn [void]
     # @return [Any] built instance
     def forge(*traits, **overrides)
-      # @type var traits: Array[(Array[Symbol] | Hash[Symbol, untyped])]
-      traits, overrides = check_traits_and_overrides(traits, overrides)
-      attributes = @parameters.attributes.merge(*@parameters.traits.values_at(*traits), overrides)
-      attributes = Crucible.new(attributes).resolve!
-
-      instance = forged.new(attributes)
+      resolved_attributes = resolve_attributes(traits, overrides)
+      instance = build_instance(resolved_attributes)
       yield instance if block_given?
       instance
     end
@@ -90,19 +86,13 @@ module ObjectForge
 
     private
 
-    def check_traits_and_overrides(traits, overrides)
-      unless traits.size == 2 && overrides.empty?
-        # @type var traits: Array[Symbol]
-        # @type var overrides: Hash[Symbol, untyped]
-        return [traits, overrides]
-      end
+    def resolve_attributes(traits, overrides)
+      attributes = @parameters.attributes.merge(*@parameters.traits.values_at(*traits), overrides)
+      Crucible.new(attributes).resolve!
+    end
 
-      case traits
-      in [Array => real_traits, Hash => real_overrides]
-        [real_traits, real_overrides]
-      else
-        [traits, overrides]
-      end
+    def build_instance(attributes)
+      forged.new(attributes)
     end
   end
 end

--- a/lib/object_forge/forgeyard.rb
+++ b/lib/object_forge/forgeyard.rb
@@ -56,7 +56,7 @@ module ObjectForge
     #
     # @raise [KeyError] if forge with the specified name is not registered
     def forge(name, *traits, **overrides, &)
-      @forges.fetch(name)[traits, overrides, &]
+      @forges.fetch(name)[*traits, **overrides, &]
     end
 
     alias build forge

--- a/lib/object_forge/sequence.rb
+++ b/lib/object_forge/sequence.rb
@@ -32,7 +32,7 @@ module ObjectForge
       end
 
       @initial = initial
-      @container = Concurrent::MVar.new(initial)
+      @container = Concurrent::MVar.new(initial) # steep:ignore UnknownConstant
     end
 
     # Get the next value in the sequence, starting with the initial value.

--- a/sig/object_forge.rbs
+++ b/sig/object_forge.rbs
@@ -1,13 +1,12 @@
 module ObjectForge
-  class Error < StandardError
-  end
-  class DSLError < Error
-  end
+  type sequenceable = ObjectForge::_RespondTo & ObjectForge::_Sequenceable
 
-  interface _Sequenceable
-    def succ: -> self
+  interface _RespondTo
     def respond_to?: (Symbol name, ?bool include_private) -> bool
     def class: -> Class
+  end
+interface _Sequenceable
+    def succ: -> self
   end
   interface _Forgable
     def new: (Hash[Symbol, untyped]) -> self
@@ -17,11 +16,16 @@ module ObjectForge
     def traits: () -> Hash[Symbol, Hash[Symbol, untyped]]
   end
 
+  class Error < StandardError
+  end
+  class DSLError < Error
+  end
+
   VERSION: String
   DEFAULT_YARD: ObjectForge::Forgeyard
 
   def self.sequence
-    : (?(ObjectForge::_Sequenceable | ObjectForge::Sequence) initial) -> ObjectForge::Sequence
+    : (?(ObjectForge::sequenceable | ObjectForge::Sequence) initial) -> ObjectForge::Sequence
 
   def self.define
     : (Symbol name, ObjectForge::_Forgable forged) { (ObjectForge::ForgeDSL) -> void } -> ObjectForge::Forge
@@ -33,15 +37,15 @@ end
 
 class ObjectForge::Sequence
   def self.new
-    : (?(ObjectForge::_Sequenceable | ObjectForge::Sequence) initial) -> ObjectForge::Sequence
+    : (?(ObjectForge::sequenceable | ObjectForge::Sequence) initial) -> ObjectForge::Sequence
   
-  attr_reader initial: ObjectForge::_Sequenceable
+  attr_reader initial: ObjectForge::sequenceable
   
-  def initialize: (ObjectForge::_Sequenceable initial) -> void
+  def initialize: (ObjectForge::sequenceable initial) -> void
 
-  def next: -> ObjectForge::_Sequenceable
+  def next: -> ObjectForge::sequenceable
 
-  def reset: -> ObjectForge::_Sequenceable
+  def reset: -> ObjectForge::sequenceable
   alias rewind reset
 end
   
@@ -68,7 +72,7 @@ class ObjectForge::Forge
   class Parameters
     include ObjectForge::_ForgeParameters
 
-    def intitialize
+    def initialize
       : (attributes: Hash[Symbol, untyped], traits: Hash[Symbol, Hash[Symbol, untyped]]) -> void
   end
 
@@ -84,19 +88,21 @@ class ObjectForge::Forge
   
   def forge
     : (*Symbol traits, **untyped overrides) ?{ (untyped) -> void } -> ObjectForge::_Forgable
-    | (Array[Symbol] traits, Hash[Symbol, untyped] overrides) ?{ (untyped) -> void } -> ObjectForge::_Forgable
   alias build forge
   alias [] forge
 
   private
 
-  def check_traits_and_overrides
-    : (Array[Symbol] traits, Hash[Symbol, untyped] overrides) -> [Array[Symbol], Hash[Symbol, untyped]]
-   | (Array[(Array[Symbol] | Hash[Symbol, untyped])], Hash[Symbol, untyped]) -> [Array[Symbol], Hash[Symbol, untyped]]
+  def resolve_attributes
+    : (Array[Symbol] traits, Hash[Symbol, untyped] overrides) -> Hash[Symbol, untyped]
+
+  def build_instance
+    : (Hash[Symbol, untyped] attributes) -> ObjectForge::_Forgable
 end
 
 class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
   include ObjectForge::_ForgeParameters
+
   attr_reader sequences: Hash[Symbol, ObjectForge::Sequence]
 
   @attributes: Hash[Symbol, Proc]
@@ -110,12 +116,11 @@ class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
   def freeze: -> self
 
   def attribute
-    : (Symbol name) { -> untyped } -> Symbol
-    | (Symbol name) { (ObjectForge::_Sequenceable) -> untyped } -> Symbol
+    : (Symbol name) { [self: ObjectForge::Crucible] -> untyped } -> Symbol
   alias [] attribute
 
   def sequence
-    : (Symbol name, ?(ObjectForge::_Sequenceable | ObjectForge::Sequence) initial) { (ObjectForge::_Sequenceable) -> untyped } -> Symbol
+    : (Symbol name, ?(ObjectForge::sequenceable | ObjectForge::Sequence) initial) { (ObjectForge::sequenceable) [self: ObjectForge::Crucible] -> untyped } -> Symbol
 
   def trait
     : (Symbol name) { (self) -> void } -> Symbol
@@ -125,7 +130,7 @@ class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
   private
 
   def method_missing
-    : (Symbol name) { -> untyped } -> Symbol
+    : (Symbol name) { [self: ObjectForge::Crucible] -> untyped } -> Symbol
     # After freezing:
     | (Symbol name) { -> untyped } -> void
 
@@ -182,5 +187,5 @@ class ObjectForge::UnBasicObject < BasicObject
 
   def block_given?: -> bool
 
-  def raise: (_Exception exception, ?String message) -> void
+  def raise: (_Exception exception, ?String message, ?Array[String] backtrace, ?cause: _Exception) -> void
 end

--- a/spec/object_forge/forge_spec.rb
+++ b/spec/object_forge/forge_spec.rb
@@ -50,18 +50,6 @@ module ObjectForge
         it "builds an instance of the forged class, applying traits and overrides in order" do
           expect(forge.forge(:barfoo, :bazoo, foo: 3)).to eq forged_class.new(foo: 3, bar: 3)
         end
-
-        context "if traits and overrides are passed as two positional parameters" do
-          it "works the same" do
-            expect(forge.forge(%i[barfoo bazoo], { foo: 3 })).to eq forged_class.new(foo: 3, bar: 3)
-          end
-        end
-
-        context "if only two traits are passed" do
-          it "does not try to parse them as traits and overrides" do
-            expect(forge.forge(:barfoo, :bazoo)).to eq forged_class.new(foo: :baz, bar: :baz)
-          end
-        end
       end
 
       context "with a block" do

--- a/spec/object_forge/forgeyard_spec.rb
+++ b/spec/object_forge/forgeyard_spec.rb
@@ -69,14 +69,14 @@ module ObjectForge
       context "with a single argument" do
         it "builds an instance through named forge with default parameters" do
           expect(forgeyard.forge(:test)).to be instance
-          expect(forge).to have_received(:[]).with([], {})
+          expect(forge).to have_received(:[]).with(no_args)
         end
       end
 
       context "with multiple arguments" do
         it "builds an instance through named forge with specified parameters" do
           expect(forgeyard.forge(:test, :trait, attribute: 2)).to be instance
-          expect(forge).to have_received(:[]).with([:trait], { attribute: 2 })
+          expect(forge).to have_received(:[]).with(:trait, attribute: 2)
         end
       end
 
@@ -88,13 +88,13 @@ module ObjectForge
 
         it "allows tapping into the object" do
           expect(forgeyard[:test] { _1.foo = 33 }).to eq forged_class.new(foo: 33, bar: 2)
-          expect(forge).to have_received(:[]).with([], {})
+          expect(forge).to have_received(:[]).with(no_args)
         end
 
         it "runs the block after forging the object with resolved attributes" do
           expect(forgeyard[:test, foo: :foo, bar: -> { foo }] { _1.foo = 33 })
             .to eq forged_class.new(foo: 33, bar: :foo)
-          expect(forge).to have_received(:[]).with([], { foo: :foo, bar: Proc })
+          expect(forge).to have_received(:[]).with(foo: :foo, bar: Proc)
         end
       end
 


### PR DESCRIPTION
- Fix a problem caused by `Forge#forge` having two different signatures. I believe this is a bug in Steep (reported here https://github.com/soutaro/steep/issues/1811). Now, `#forge` works with `*` and `**` only, simplifying the implementation. While technically a breaking change, nobody uses this anyway.
- Ignore a warning on `Concurrent::MVar`. This is an issue in RBS collection.
- Additionally, make `bin/benchmark` save reports to look at later.