### PR TITLE
Set up deployment of YARD docs to GitHub Pages

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Code quality
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: 'development'
+      BUNDLE_ONLY: 'default linting'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -31,7 +31,7 @@ jobs:
     name: Type checking
     runs-on: ubuntu-latest
     env:
-      BUNDLE_WITHOUT: 'development'
+      BUNDLE_ONLY: 'default linting'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -52,7 +52,7 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      BUNDLE_WITHOUT: 'development'
+      BUNDLE_ONLY: 'default test'
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,54 @@
+name: Deploy documentation to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: 'default documentation'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Generate documentation
+        run: bundle exec rake docs
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'doc'
+  deploy:
+    runs-on: ubuntu-latest
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,2 @@
+--tag "thread_safety:Thread safety"
+--main README.md

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,17 @@ source "https://rubygems.org"
 
 gemspec
 
-# For running checks
+# For running tasks
 gem "rake", require: false
+
+group :test do
+  # Testing framework
+  gem "rspec", require: false
+
+  # Code coverage report
+  gem "simplecov", require: false
+  gem "simplecov_lcov_formatter", require: false
+end
 
 group :linting do
   # Linting
@@ -22,19 +31,13 @@ group :linting do
   gem "steep", require: false
 end
 
-group :test do
-  # Testing framework
-  gem "rspec", require: false
-
-  # Code coverage report
-  gem "simplecov", require: false
-  gem "simplecov_lcov_formatter", require: false
+group :documentation do
+  # Documentation
+  gem "redcarpet", require: false
+  gem "yard", require: false
 end
 
 group :development do
-  # Documentation
-  gem "yard", require: false
-
   # Version changes
   gem "bump", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       ffi (~> 1.0)
     rbs (3.9.4)
       logger
+    redcarpet (3.6.1)
     regexp_parser (2.10.0)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -192,6 +193,7 @@ DEPENDENCIES
   object_forge!
   rake
   rbs
+  redcarpet
   rspec
   rubocop (~> 1.72)
   rubocop-packaging

--- a/lib/object_forge/forge_dsl.rb
+++ b/lib/object_forge/forge_dsl.rb
@@ -27,9 +27,6 @@ module ObjectForge
     # @return [Hash{Symbol => Hash{Symbol => Proc}}] trait definitions
     attr_reader :traits
 
-    # @return [#call, nil] forge mold
-    attr_reader :mold
-
     # Define forge's parameters through DSL.
     #
     # If the block has a parameter, an object will be yielded,
@@ -79,18 +76,25 @@ module ObjectForge
       self
     end
 
+    # @return [#call, nil] forge mold
+    # @since 0.2.0
+    def mold # rubocop:disable Style/TrivialAccessors
+      # Not using attr_reader because YARD eats `#mold=` then.
+      @mold
+    end
+
     # Set the forge mold.
     #
     # Mold is an object that knows how to take a hash of attributes
     # and create an object from them.
     # It can also be a class with +#call+, in which case a new mold will be instantiated
-    # automatically for each build. If a single instance is enough,
-    # please call +.new+ yourself once.
+    # automatically for each build through {Molds::WrappedMold}.
+    # If a single instance is enough, please call +.new+ yourself once.
     #
     # @since 0.2.0
     #
     # @param mold [Class, #call, nil]
-    # @return [Class, #call, nil]
+    # @return [#call, nil] the set mold
     #
     # @raise [DSLError] if +mold+ does not respond to or implement +#call+
     def mold=(mold)

--- a/lib/object_forge/molds.rb
+++ b/lib/object_forge/molds.rb
@@ -10,7 +10,7 @@ module ObjectForge
   #
   # A simple mold can easily be just a +Proc+.
   # All molds must have the following +#call+ signature: +call(forged:, attributes:, **)+.
-  # The extra keywords are for future extensions.
+  # The extra keywords are ignored for possibility of future extensions.
   #
   # @example A very basic FactoryBot replacement
   #   creator = ->(forged:, attributes:, **) do

--- a/lib/object_forge/molds/keywords_mold.rb
+++ b/lib/object_forge/molds/keywords_mold.rb
@@ -4,7 +4,8 @@ module ObjectForge
   module Molds
     # Basic mold which calls +forged.new(**attributes)+.
     #
-    # Can be used instead of {SingleArgumentMold},
+    # Can be used instead of {SingleArgumentMold}
+    # due to how keyword arguments are treated in Ruby,
     # but performance is about 1.5 times worse.
     #
     # @thread_safety Thread-safe.

--- a/lib/object_forge/molds/wrapped_mold.rb
+++ b/lib/object_forge/molds/wrapped_mold.rb
@@ -7,6 +7,8 @@ module ObjectForge
     # Wrapping a mold class is useful when its +#call+ is stateful,
     # making it unsafe to use multiple times or in shared environments.
     #
+    # This mold is usually automatically used through {ForgeDSL#mold=}.
+    #
     # @thread_safety Thread-safe if {wrapped_mold} does not use global state.
     # @since 0.2.0
     class WrappedMold

--- a/object_forge.gemspec
+++ b/object_forge.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { File.basename(_1) }
 
-  spec.rdoc_options = ["--tag", "thread_safety:Thread safety"]
+  spec.rdoc_options = ["--tag", "thread_safety:Thread safety", "--main", "README.md"]
 
   spec.add_dependency "concurrent-ruby", "~> 1.2"
 end


### PR DESCRIPTION
- Add worklflow to build and publish YARD docs on push to `main`.
- Add RedCarpet to properly process README.md.
- Limit number of gems installed for different jobs.
- Improve some documentation.