### PR TITLE
Fix deploy-docs workflow not declaring jobs dependency

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,14 +15,14 @@ jobs:
   lint:
     name: Code quality
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ONLY: 'default linting'
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_ONLY: 'default linting'
       with:
         bundler-cache: true
     - name: Run RuboCop
@@ -30,14 +30,14 @@ jobs:
   typing:
     name: Type checking
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ONLY: 'default linting'
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_ONLY: 'default linting'
       with:
         bundler-cache: true
     - name: Install RBS collection
@@ -51,14 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    env:
-      BUNDLE_ONLY: 'default test'
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
+      env:
+        BUNDLE_ONLY: 'default test'
       with:
         bundler-cache: true
     - name: Run RSpec

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,14 +15,14 @@ jobs:
   lint:
     name: Code quality
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: 'default linting'
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      env:
-        BUNDLE_ONLY: 'default linting'
       with:
         bundler-cache: true
     - name: Run RuboCop
@@ -30,14 +30,14 @@ jobs:
   typing:
     name: Type checking
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: 'default linting'
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      env:
-        BUNDLE_ONLY: 'default linting'
       with:
         bundler-cache: true
     - name: Install RBS collection
@@ -51,14 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    env:
+      BUNDLE_ONLY: 'default test'
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
-      env:
-        BUNDLE_ONLY: 'default test'
       with:
         bundler-cache: true
     - name: Run RSpec

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,24 +1,20 @@
 name: Deploy documentation to GitHub Pages
-
 on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
 permissions:
   contents: read
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   build:
+    if: ${{ github.repository == 'trinistr/object_forge' }}
     runs-on: ubuntu-latest
     env:
       BUNDLE_ONLY: 'default documentation'
@@ -41,6 +37,7 @@ jobs:
           path: 'doc'
   deploy:
     runs-on: ubuntu-latest
+    needs: build
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       pages: write

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,13 +1,10 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
-
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["**"]
-
 permissions: {}
-
 jobs:
   zizmor:
     runs-on: ubuntu-latest
@@ -18,6 +15,5 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2

--- a/lib/object_forge/molds/struct_mold.rb
+++ b/lib/object_forge/molds/struct_mold.rb
@@ -12,6 +12,8 @@ module ObjectForge
       # Does Struct automatically use keyword initialization
       # when +keyword_init+ is not specified / +nil+?
       #
+      # This should be true on Ruby 3.2.0 and later.
+      #
       # @return [Boolean]
       RUBY_FEATURE_AUTO_KEYWORDS = (::Struct.new(:a, :b).new(a: 1, b: 2).a == 1)
 


### PR DESCRIPTION
* Add `needs` key that was accidentally left out, leading to deployment of outdated artifact.
* Limit docs building to this repository only.