### PR TITLE
Add transient attributes / attribute listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+**Added**
+- `:attribute_list` option in `Forge`, which is an allowlist of attributes to be passed to the mold.
+- `transient` keyword arguments in `ForgeDSL#attribute` and `ForgeDSL#sequence` which marks an attribute to be excluded from attribute list.
+- `#transient` method in `ForgeDSL` which is a shortcut for `attribute(name, transient: true)`.
+
+**Changed**
+- If any `transient` attributes are specified in `ForgeDSL`, an `attribute_list` will be automatically generated to exclude them.
+- `Forge` will automatically reorder attributes by `:attribute_list` if specified.
+
 [Compare v0.4.0...main](https://github.com/trinistr/object_forge/compare/v0.4.0...main)
 
 ## [v0.4.0] — 2026-05-28
+
+This update adds more customization options to the forge system. Especially useful are blocks to be executed after an object is forged.
 
 **Added**
 - `:crucible` option (previously known as settings) in `Forge`, allowing to replace `Crucible` with any `call`-able object. May be useful to provide a faster attributes resolver.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 [![CI](https://github.com/trinistr/object_forge/actions/workflows/CI.yaml/badge.svg)](https://github.com/trinistr/object_forge/actions/workflows/CI.yaml)
 
 > [!TIP]
+>
 > You may be viewing documentation for an older (or newer) version of the gem than intended. Look at [Changelog](https://github.com/trinistr/object_forge/blob/main/CHANGELOG.md) to see all versions, including unreleased changes.
 
-***
+---
 
 **ObjectForge** is a small factory library for Ruby objects with minimal assumptions about framework, persistence, or runtime environment.
 
 It is designed for cases where factory-style object construction is useful, but Rails-oriented or database-oriented tooling is a poor fit. **ObjectForge** works well with plain Ruby objects, hashes, structs, and custom build flows.
 
 The library focuses on:
+
 - explicit configuration over hidden conventions
 - support for independent registries and standalone factories
 - replaceable components based on simple interfaces
@@ -25,12 +27,13 @@ If you need factory-style object generation without coupling it to Rails, Active
 - [Motivation](#motivation)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Quick start](#quick-start)
-  - [Basics](#basics)
-  - [Independent forgeyards and forges](#independent-forgeyards-and-forges)
-  - [Molds: configuring object construction](#molds-configuring-object-construction)
-  - [After-build customization](#after-build-customization)
-  - [Performance tips](#performance-tips)
+    - [Quick start](#quick-start)
+    - [Basics](#basics)
+    - [Independent forgeyards and forges](#independent-forgeyards-and-forges)
+    - [Defining final attribute list](#defining-final-attribute-list)
+    - [Molds: configuring object construction](#molds-configuring-object-construction)
+    - [After-build customization](#after-build-customization)
+    - [Performance tips](#performance-tips)
 - [Differences and limitations (compared to FactoryBot)](#differences-and-limitations-compared-to-factorybot)
 - [Current and planned features (roadmap)](#current-and-planned-features-roadmap)
 - [Development](#development)
@@ -44,12 +47,14 @@ Ruby already has well-known factory libraries, especially FactoryBot and Fabrica
 **ObjectForge** aims at a different problem space: building objects with a factory-style workflow while making as few assumptions as possible about framework, storage, object lifecycle, or application structure.
 
 **ObjectForge** is particularly useful when:
+
 - the objects being built are plain Ruby objects rather than database-backed records
 - object generation is needed outside of tests, such as in services, scripts, or fixtures
 - multiple independent sets of factories need to coexist in the same project
 - construction behavior should be explicit and configurable rather than hidden behind framework conventions
 
 The project is intentionally small in scope. Rather than trying to model every style of factory workflow, it focuses on a compact, understandable core:
+
 - a DSL for defining attributes, sequences, and traits
 - forges (factories) and forgeyards (registries)
 - several object molds (constructors)
@@ -60,25 +65,30 @@ The goal is to have a simple, composable tool that you can easily reach for when
 ## Installation
 
 Install with `gem`:
+
 ```sh
 gem install object_forge
 ```
 
 Or, if using Bundler, add to your Gemfile:
+
 ```ruby
 gem "object_forge"
 ```
+
 and run `bundle install`.
 
 ## Usage
 
 > [!Note]
+>
 > - Latest documentation from `main` branch is automatically deployed to [GitHub Pages](https://trinistr.github.io/object_forge).
 > - Documentation for published versions is available on [RubyDoc](https://rubydoc.info/gems/object_forge).
 
 ### Quick start
 
 Create your domain logic class:
+
 ```ruby
 class Rectangle
   def initialize(length:, width:)
@@ -93,8 +103,10 @@ end
 ```
 
 Define a forge:
+
 ```ruby
 require "object_forge"
+
 ObjectForge.define(:rectangle, Rectangle) do |f|
   f.mold = ObjectForge::Molds::KeywordsMold.new
 
@@ -108,6 +120,7 @@ end
 ```
 
 Forge some objects!
+
 ```ruby
 ObjectForge.forge(:rectangle) # => [63x27]
 ObjectForge.forge(:rectangle, :square) # => [56x56]
@@ -120,6 +133,7 @@ ObjectForge.forge(:rectangle, :square, length: 123) # => [123x123]
 In the simplest cases, **ObjectForge** can be used much like other factory libraries, with definitions living in a global object (`ObjectForge::DEFAULT_YARD`). In this case, methods are called directly on `ObjectForge` module.
 
 Forges are defined using a DSL:
+
 ```ruby
 # Example class:
 Point = Struct.new(:id, :x, :y)
@@ -134,8 +148,8 @@ ObjectForge.define(:point, Point) do |f|
   f[:y] { rand(-delta..delta) }
   # There is also the familiar shortcut using `method_missing`:
   f.delta { 0.5 * amplitude }
-  # Notice how transient attributes don't require any special syntax:
-  f.amplitude { 1 }
+  # Depending on the class, transient attributes may need to be explicitly marked:
+  f.transient(:amplitude) { 1 }
   # `#sequence` defines a sequenced attribute (starting with 1 by default):
   f.sequence(:id, "a")
   # Traits allow to group and reuse related values:
@@ -154,6 +168,7 @@ end
 ```
 
 A forge builds objects, using attributes hash:
+
 ```ruby
 ObjectForge.call(:point)
   # => #<struct Point id="a", x=0.17176955469852973, y=0.3423901951181103>
@@ -173,12 +188,15 @@ ObjectForge.call(:point, :z, x: -> { rand(100..200) + delta })
 ObjectForge.call(:point, :z) { puts "#{_1.id}: #{_1.x},#{_1.y}" }
   # outputs "Z_e: 0.0,0.0"
 ```
+
 > [!TIP]
+>
 > Forging can be done through any of `#call`, `#forge`, or `#build` methods, they are aliases.
 
 ### Independent forgeyards and forges
 
 It is possible and *encouraged* to create multiple forgeyards, each with its own set of forges:
+
 ```ruby
 forgeyard = ObjectForge::Forgeyard.new
 forgeyard.define(:dot, Point) do |f|
@@ -191,18 +209,21 @@ end
 ```
 
 Now, this forgeyard can be used just like the default one:
+
 ```ruby
 forgeyard.forge(:dot, :z, id: "0")
   # => #<struct Point id="0", x=0, y=0>
 ```
 
 Note how the forge isn't registered in the default forgeyard:
+
 ```ruby
 ObjectForge.forge(:dot)
   # KeyError: key not found
 ```
 
 If you find it more convenient not to use a forgeyard (for example, if you only need a single forge for your service), you can create individual forges:
+
 ```ruby
 forge = ObjectForge::Forge.define(Point) do |f|
   f.sequence(:id, "a")
@@ -214,6 +235,7 @@ end
 ```
 
 **Forge** has the same building interface as a **Forgeyard**, but it doesn't have the name argument:
+
 ```ruby
 forge.build
   # => #<struct Point id="a", x=0.3317733939650964, y=-0.1363936629550252>
@@ -223,21 +245,74 @@ forge.(radius: 500)
   # => #<struct Point id="c", x=-141, y=109>
 ```
 
+### Defining final attribute list
+
+Depending on what you are forging and the [mold](#molds-configuring-object-construction) used, you may need to limit the attributes that are passed to the forged instance. This can be done by using either `transient` attributes or the `attribute_list` option in the forge definition. Both options are equivalent in the end, so the choice is yours.
+
+#### Transient attributes
+
+Transient attributes can be defined using the `transient` method or `transient: true` argument. This automatically sets up attribute list to exclude the attribute, but otherwise doesn't change the behavior.
+
+```ruby
+# Note that this forge is forging a Hash, not a Struct.
+ObjectForge.define(:point, Hash) do |f|
+  # Transient "radius" is excluded from final attribute list:
+  f.transient(:radius) { 0.5 }
+  # Sequences can be transient too:
+  f.sequence(:s, transient: true) { |s| s * 30 }
+
+  f.x { s + rand(-radius..radius) }
+  f.y { s + rand(-radius..radius) }
+end
+
+ObjectForge.forge(:point)
+  # => {x: 30.092699961573118, y: 29.71344463733288}
+```
+
+#### Attribute list
+
+`transient` attributes are really just a convenient shortcut to specifying `attribute_list` option. Manually setting the list can be handy if uniform attribute definitions are desired, it is semantically meaningful to allowlist attributes rather than deny individually, or transient attributes don't appear in the definition. `attribute_list` can also be useful to define attribute ordering.
+
+```ruby
+ObjectForge.define(:point, Hash) do |f|
+  f.attribute_list = %i[x y z]
+  # Parameters:
+  f.unit { :m } # Meters by default
+  f.conversion { { mm: 10.0**0, m: 10.0**3, km: 10.0**6 } } # Conversion multipliers table
+  # Final attribute calculations:  
+  f.x { position[0] * conversion[unit] }
+  f.z { position[1] * conversion[unit] }
+  f.y { altitude * conversion[unit] }
+end
+
+# Note how `y` comes out as the second attribute, not the third:
+ObjectForge.forge(:point, position: [10, 13.4], altitude: 5)
+  # => {x: 10000.0, y: 5000.0, z: 13400.0}
+ObjectForge.forge(:point, position: [10, 13.4], altitude: 5, unit: :mm)
+  # => {x: 10.0, y: 5.0, z: 13.4}
+```
+
+> [!NOTE]
+>
+> `attribute_list` and `transient` attributes can be used in the same definition. However, transient attributes *can't* appear in attribute list; this will raise an error.
+
 ### Molds: configuring object construction
 
 If you use core Ruby data containers, such as `Struct`, `Data` or even `Hash`, they will "just work". However, if a custom class is used, forging will probably fail, unless your class happens to take a hash of attributes in `#initialize`. It would be against the goal of **ObjectForge** to place requirements on your classes, and indeed there is a solution.
 
 Whenever you need to change how your objects are built, you specify a *mold*. Molds are just `call`able objects (including `Proc`s!) with specific arguments. They are set in forge definition:
+
 ```ruby
 forge = ObjectForge::Forge.define(Point) do |f|
   f.mold = ->(forge_target:, attributes:, **) do
     forge_target.new(attributes[:id], attributes[:x].round(3), attributes[:y].round(3))
   end
-  #... rest of the definition from the previous example
+  #... rest of the definition from the Basics example
 end
 ```
 
 Now the specified **mold** will be called to build your objects:
+
 ```ruby
 forge.forge
   # => #<struct Point id="a", x=0.331, y=-0.136>
@@ -245,25 +320,32 @@ forge.forge
 
 Of course, you can abuse this to your heart's content. Look at the documentation for `ObjectForge::Molds` for inspiration.
 
+> [!NOTE]
+>
+> If you don't specify a mold, **ObjectForge** will infer one for core data containers, including **Hash**, **Struct**, and **Data** subclasses.
+
 **ObjectForge** comes pre-equipped with a selection of molds for common cases:
+
 - `ObjectForge::Molds::SingleArgumentMold` (*the default*) calls `new(attributes)`, suitable for **ActiveModel**-style objects and **Dry::Struct**, as an example
 - `ObjectForge::Molds::KeywordsMold` calls `new(**attributes)`, suitable for **Data** and similar classes
 - `ObjectForge::Molds::HashMold` allows building **Hash** (including subclasses), providing a way to easily use build hashes
 - `ObjectForge::Molds::StructMold` handles all possible cases of `keyword_init` for **Struct**s
 
-> [!NOTE]
-> If you don't specify a mold, **ObjectForge** will infer one for core data containers, including **Hash**, **Struct**, and **Data** subclasses.
+You can also set a Class with a `#call` method as a mold. It will be instantiated on every call, providing a clean mold object.
 
 > [!TIP]
-> It is recommended to use molds instances directly. Using classes causes memory churn and lowered performance. Not only that, but having a stateful mold is a code smell and probably represents a significant design issue.
+>
+> It is recommended to use mold instances. Using classes causes memory churn and lowers performance. Not only that, but having a stateful mold is a code smell.
 
 ### After-build customization
 
 If there is a need to modify the object or perform additional actions after it is forged, there are two mechanisms you can employ:
+
 - after-forge hook
 - customization block
 
 After-forge hook is a `call`able object specified as part of forge definition. It runs every time forging happens:
+
 ```ruby
 forge = ObjectForge::Forge.define(Rectangle) do |f|
   # can also be specified as `after_build`
@@ -276,6 +358,7 @@ forge.forge
 ```
 
 Customization block is an optional block argument to `#forge` and is only executed in that specific invocation:
+
 ```ruby
 forge.forge { |rect| RectangleRepository.save(rect); puts "persisted!" }
   # Used 621 sq. units
@@ -283,11 +366,14 @@ forge.forge { |rect| RectangleRepository.save(rect); puts "persisted!" }
   # => [23x27]
 ```
 
-If both hook and block are used, the hook runs before the block. 
+> [!NOTE]
+>
+> If both hook and block are used, the hook runs before the block. 
 
 ### Performance tips
 
 **ObjectForge** is pretty fast for what it is. However, if you are worried, there are certain things that can be done to make it faster.
+
 - The easiest thing is to enable [**YJIT**](https://docs.ruby-lang.org/en/master/yjit/yjit_md.html). It will probably speed up your whole application, but be aware that it is not always suitable and may even degrade performance on some workloads. It *is* considered production-ready though.
 - Calling a **Forge** directly, instead of through **Forgeyard**, is faster due to not needing argument forwarding. This is consistent (but check on your system anyway!).
 - Using `self[:name]` instead of plain `name` inside attribute definitions does not engage dynamic method dispatch, which *should* be faster. However, micro-benchmarking does not show conclusive results.
@@ -297,24 +383,28 @@ If both hook and block are used, the hook runs before the block.
 If you are used to FactoryBot, be aware that there are quite a few differences in specifics.
 
 General:
+
 - The user (you) is responsible for loading forge definitions, there are no search paths. If **ObjectForge** is used in tests, it should be enough to add something like `Dir["spec/forges/**/*.rb].each { require _1 }` to your `spec_helper.rb` (or `rails_helper.rb`).
 - `Forgeyard.define` *is* the forge definition block, there is no separate `factory` block.
 
 Forge definition:
+
 - Class specification for a forge is non-optional, there is no assumption about the class name.
 - If the DSL block declares a block argument, `self` context is not changed, and DSL methods can't be called with an implicit receiver.
 - There is no forge inheritance or nesting.
 
 Attributes:
-- Currently, there is no concept of transient attributes. Attribute selection needs to be handled by the mold.
+
 - *There are no associations*. If nested objects are required, they should be created and set in the block for the attribute.
 
 Traits:
+
 - Traits can't be defined inside of other traits.
 - Traits can't be called from other traits. This may change in the future.
 - There are no default traits.
 
 Sequences:
+
 - There is no explicit way to define shared sequences, but a freestanding `Sequence` can be created manually and passed into `sequence` calls.
 - Sequences work with values implementing `#succ`, not `#next`, expressly prohibiting `Enumerator`. This may be relaxed in the future.
 
@@ -333,8 +423,8 @@ kanban
     [Built-in Hash, Struct, Data builders / molds]
     [Ability to replace resolver]
     [After-build hook]
-  [⚗️ To do]
     [Transient attributes / attribute filtering]
+  [⚗️ To do]
   [❔ Maybe, maybe not]
     [Calling traits from traits]
     [Default traits]

--- a/lib/object_forge/forge.rb
+++ b/lib/object_forge/forge.rb
@@ -29,10 +29,12 @@ module ObjectForge
     # @!attribute [r] options
     #   A forge's options.
     #   Known options:
-    #   - +:mold+ — a +call+able object that knows how to build the instance,
-    #     taking a class and a hash of attributes.
     #   - +:crucible+ — a +call+able object that knows how to resolve attributes,
     #     taking a hash of initial attributes.
+    #   - +:attribute_list+ — an array of attribute names to filter and sort by
+    #     before passing attributes to the mold.
+    #   - +:mold+ — a +call+able object that knows how to build the instance,
+    #     taking a class and a hash of attributes.
     #   - +:after_forge+/+:after_build+ — a +call+able object that is passed
     #     the forged instance and can do anything with it.
     #   @since 0.3.0
@@ -103,6 +105,7 @@ module ObjectForge
     # @raise [ArgumentError] if a trait name is unknown
     def forge(*traits, **overrides)
       resolved_attributes = resolve_attributes(traits, overrides)
+      resolved_attributes = apply_attribute_list(resolved_attributes)
       instance = @mold.call(forge_target: @forge_target, attributes: resolved_attributes)
       @after_forge_hook&.call(instance)
       yield instance if block_given?
@@ -191,6 +194,16 @@ module ObjectForge
 
       attributes = @parameters.attributes.merge(*@parameters.traits.values_at(*traits), overrides)
       @crucible.call(attributes)
+    end
+
+    # Filter and sort attributes based on the attribute list.
+    #
+    # @param attributes [Hash{Symbol => Any}]
+    # @return [Hash{Symbol => Any}]
+    def apply_attribute_list(attributes)
+      return attributes unless (attribute_list = @parameters.options[:attribute_list])
+
+      attributes.slice(*attribute_list)
     end
   end
 end

--- a/lib/object_forge/forge_dsl.rb
+++ b/lib/object_forge/forge_dsl.rb
@@ -17,7 +17,7 @@ module ObjectForge
   #   The instance itself is frozen after initialization,
   #   so it should be safe to share.
   # @since 0.1.0
-  class ForgeDSL < UnBasicObject
+  class ForgeDSL < UnBasicObject # rubocop:disable Metrics/ClassLength
     # @return [Hash{Symbol => Proc}] attribute definitions
     attr_reader :attributes
 
@@ -61,9 +61,11 @@ module ObjectForge
       @sequences = {}
       @traits = {}
       @options = {}
+      @transient_attributes = []
 
       dsl.arity.zero? ? instance_exec(&dsl) : yield(self)
 
+      shape_attribute_list!
       freeze
     end
 
@@ -79,6 +81,7 @@ module ObjectForge
       @sequences.freeze
       @traits.freeze
       @options.freeze
+      @options[:attribute_list].freeze
       self
     end
 
@@ -133,13 +136,20 @@ module ObjectForge
     #   f.attribute(:[]=) { "#{self[:[]]} are brackets" }
     #   f.attribute(:!) { "#{self[:[]=]}!" }
     #
+    # @example using transient attributes
+    #   f.attribute(:range) { (base - delta)..(base + delta) }
+    #   f.attribute(:base, transient: true) { 1 }
+    #   f.transient(:delta) { 0.05 }
+    #
     # @param name [Symbol] attribute name
+    # @param transient [Boolean] whether the attribute is transient
+    #   (automatically excluded from attribute list)
     # @yieldreturn [Any] attribute value
     # @return [Symbol] attribute name
     #
     # @raise [TypeError] if +name+ is not a Symbol
     # @raise [DSLError] if no block is given
-    def attribute(name, &definition)
+    def attribute(name, transient: false, &definition)
       unless ::Symbol === name
         raise ::TypeError,
               "attribute name must be a Symbol, #{name.class} given (in #{name.inspect})"
@@ -153,11 +163,19 @@ module ObjectForge
       else
         @attributes[name] = definition
       end
+      @transient_attributes << name if transient
 
       name
     end
 
     alias [] attribute
+
+    # Define a transient attribute.
+    #
+    # @see #attribute
+    def transient(name, &)
+      attribute(name, transient: true, &)
+    end
 
     # Define an attribute, using a sequence.
     #
@@ -182,13 +200,15 @@ module ObjectForge
     #
     # @param name [Symbol] attribute name
     # @param initial [Sequence, #succ] existing sequence, or initial value for a new sequence
+    # @param transient [Boolean] whether the attribute is transient
+    #   (automatically excluded from attribute list)
     # @yieldparam value [#succ] current value of the sequence to calculate attribute value
     # @yieldreturn [Any] attribute value
     # @return [Symbol] attribute name
     #
     # @raise [TypeError] if +name+ is not a Symbol
     # @raise [ObjectInterfaceError] if +initial+ does not respond to #succ and is not a {Sequence}
-    def sequence(name, initial = 1, **nil, &)
+    def sequence(name, initial = 1, transient: false, &)
       unless ::Symbol === name
         raise ::TypeError,
               "sequence name must be a Symbol, #{name.class} given (in #{name.inspect})"
@@ -197,9 +217,9 @@ module ObjectForge
       seq = @sequences[name] ||= Sequence.new(initial)
 
       if block_given?
-        attribute(name) { instance_exec(seq.next, &) }
+        attribute(name, transient: transient) { instance_exec(seq.next, &) }
       else
-        attribute(name) { seq.next }
+        attribute(name, transient: transient) { seq.next }
       end
 
       name
@@ -303,6 +323,19 @@ module ObjectForge
 
     def valid_option_method?(name)
       name.match?(/\A\p{Word}.*=\z/)
+    end
+
+    def shape_attribute_list!
+      return if @transient_attributes.empty?
+
+      if @options.key?(:attribute_list)
+        return if (conflicting_attrs = @transient_attributes & @options[:attribute_list]).empty?
+
+        list = conflicting_attrs.map(&:inspect).join(", ")
+        raise DSLError, "attribute_list must not include transient attributes (#{list})"
+      end
+
+      @options[:attribute_list] = @attributes.merge(*@traits.values).keys - @transient_attributes
     end
   end
 end

--- a/lib/object_forge/forge_dsl.rb
+++ b/lib/object_forge/forge_dsl.rb
@@ -12,9 +12,8 @@ module ObjectForge
   #   but it's not a private API.
   #
   # @thread_safety DSL is not thread-safe.
-  #   Take care not to introduce side effects,
-  #   especially in attribute definitions.
-  #   The instance itself is frozen after initialization,
+  #   Take care not to introduce side effects, especially in attribute definitions.
+  #   The instance itself and its attributes are frozen after initialization,
   #   so it should be safe to share.
   # @since 0.1.0
   class ForgeDSL < UnBasicObject # rubocop:disable Metrics/ClassLength

--- a/sig/object_forge.rbs
+++ b/sig/object_forge.rbs
@@ -130,6 +130,9 @@ class ObjectForge::Forge
 
   def resolve_attributes
     : (Array[Symbol] traits, Hash[Symbol, untyped] overrides) -> Hash[Symbol, untyped]
+  
+  def apply_attribute_list
+    : (Hash[Symbol, untyped] attributes) -> Hash[Symbol, untyped]
 end
 
 class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject

--- a/sig/object_forge.rbs
+++ b/sig/object_forge.rbs
@@ -144,6 +144,7 @@ class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
   @sequences: Hash[Symbol, ObjectForge::Sequence]
   @traits: Hash[Symbol, Hash[Symbol, Proc]]
   @options: Hash[Symbol, untyped]
+  @transient_attributes: Array[Symbol]
 
   def initialize
     : () { (ObjectForge::ForgeDSL) -> void } -> void
@@ -155,11 +156,14 @@ class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
     : (Symbol name, untyped value) -> Symbol
 
   def attribute
-    : (Symbol name) { [self: ObjectForge::Crucible] -> untyped } -> Symbol
+    : (Symbol name, ?transient: bool) { [self: ObjectForge::Crucible] -> untyped } -> Symbol
   alias [] attribute
 
+  def transient
+    : (Symbol name) { [self: ObjectForge::Crucible] -> untyped } -> Symbol
+
   def sequence
-    : (Symbol name, ?(ObjectForge::sequenceable | ObjectForge::Sequence) initial) { (ObjectForge::sequenceable) [self: ObjectForge::Crucible] -> untyped } -> Symbol
+    : (Symbol name, ?(ObjectForge::sequenceable | ObjectForge::Sequence) initial, ?transient: bool) { (ObjectForge::sequenceable) [self: ObjectForge::Crucible] -> untyped } -> Symbol
 
   def trait
     : (Symbol name) { (self) -> void } -> Symbol
@@ -178,6 +182,9 @@ class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
   
   def valid_option_method?
     : (Symbol name) -> bool
+  
+  def shape_attribute_list!
+    : -> void
 end
 
 class ObjectForge::Crucible < ObjectForge::UnBasicObject

--- a/spec/object_forge/forge_dsl_spec.rb
+++ b/spec/object_forge/forge_dsl_spec.rb
@@ -22,6 +22,7 @@ module ObjectForge
       let(:definition) do
         proc do |f|
           f.mold = Molds::KeywordsMold.new
+          f.attribute_list = %i[name description duration id external].freeze
 
           f.attribute(:name) { "Name" }
           f[:description] { name.upcase }
@@ -37,8 +38,9 @@ module ObjectForge
           end
 
           f.trait :useless do
-            f.useless { "Useless" }
+            f.transient(:useless) { "Useless" }
             f.sequence(:useless_id) { "Useless #{id}" }
+            f.transient(:moustached_villain) { "A-ha!" }
           end
         end
       end
@@ -52,11 +54,18 @@ module ObjectForge
         expect(forge_dsl.sequences).to be_frozen
         expect(forge_dsl.traits).to be_frozen
         expect(forge_dsl.traits.values).to all be_frozen
+        expect(forge_dsl.options).to be_frozen
       end
 
       it "contains mold in options" do
-        expect(forge_dsl.options).to match(mold: Molds::KeywordsMold)
-        expect(forge_dsl.options).to be_frozen
+        expect(forge_dsl.options).to include(mold: an_instance_of(Molds::KeywordsMold))
+      end
+
+      it "contains attribute_list in options exactly as specified" do
+        expect(forge_dsl.options).to include(
+          attribute_list: %i[name description duration id external]
+        )
+        expect(forge_dsl.options[:attribute_list]).to be_frozen
       end
 
       it "contains root attributes, including sequenced ones" do
@@ -96,7 +105,9 @@ module ObjectForge
         expect(forge_dsl.traits[:special].keys).to contain_exactly(:name, :id)
         expect(forge_dsl.traits[:special].values).to all be_a Proc
 
-        expect(forge_dsl.traits[:useless].keys).to contain_exactly(:useless, :useless_id)
+        expect(forge_dsl.traits[:useless].keys).to contain_exactly(
+          :useless, :useless_id, :moustached_villain
+        )
         expect(forge_dsl.traits[:useless].values).to all be_a Proc
       end
 
@@ -163,6 +174,42 @@ module ObjectForge
       end
     end
 
+    describe "definition without any transient attributes" do
+      let(:definition) do
+        proc do
+          attr_1 { "Name" }
+          sequence(:attr_2) { "#{attr_1} #{_1}" }
+          trait :unnamed do
+            attr_1 { nil }
+            sequence(:attr_2) { "<unnamed> #{_1}" }
+          end
+        end
+      end
+
+      it "does not set :attribute_list option" do
+        expect(forge_dsl.attributes[:attr_1]).to be_a Proc
+        expect(forge_dsl.attributes[:attr_2]).to be_a Proc
+        expect(forge_dsl.options.key?(:attribute_list)).to be false
+      end
+    end
+
+    describe "definition with conflicting attribute_list and transient attributes" do
+      let(:definition) do
+        proc do
+          self.attribute_list = %i[attr_1 attr_2].freeze
+          attribute(:attr_1) { "Name" }
+          transient(:attr_2) { "Value" }
+        end
+      end
+
+      it "fails with DSLError" do
+        expect { forge_dsl }.to raise_error(
+          DSLError,
+          "attribute_list must not include transient attributes (:attr_2)"
+        )
+      end
+    end
+
     describe "#option" do
       context "with a valid name and value" do
         let(:definition) { proc { |f| f.option(:caramba, value) } }
@@ -222,6 +269,20 @@ module ObjectForge
             expect(forge_dsl.attributes[:`].call).to eq "`Name`"
           end
         end
+
+        context "with `transient: true` metadata" do
+          let(:definition) do
+            proc do |f|
+              f.attribute(:attr_1, transient: true) { "Name" }
+              f.attribute(:attr_2) { "Name" }
+            end
+          end
+
+          it "defines an attribute Proc but excludes it from attribute_list" do
+            expect(forge_dsl.attributes[:attr_1]).to be_a Proc
+            expect(forge_dsl.options[:attribute_list]).to eq %i[attr_2]
+          end
+        end
       end
 
       context "when attribute name is not a Symbol" do
@@ -248,6 +309,23 @@ module ObjectForge
     end
 
     include_examples "has an alias", :[], :attribute
+
+    describe "#transient" do
+      let(:definition) do
+        proc { |f|
+          f.transient(:transient_attr) { "Transient Value" }
+          f.attribute(:attr_1) { "Name" }
+        }
+      end
+
+      it "defines attribute with transient metadata" do
+        expect(forge_dsl.attributes).to match(
+          transient_attr: instance_of(Proc),
+          attr_1: instance_of(Proc)
+        )
+        expect(forge_dsl.options[:attribute_list]).to eq %i[attr_1]
+      end
+    end
 
     describe "#sequence" do
       context "with valid, plain sequence definition" do

--- a/spec/object_forge/forge_spec.rb
+++ b/spec/object_forge/forge_spec.rb
@@ -116,7 +116,7 @@ module ObjectForge
     include_examples "has an alias", :build, :forge
     include_examples "has an alias", :call, :forge
 
-    describe "forge options" do
+    describe "forge options", :aggregate_failures do
       describe ":mold" do
         before do
           allow(Molds).to receive(:mold_for).and_call_original
@@ -217,6 +217,52 @@ module ObjectForge
 
           it "raises ObjectInterfaceError" do
             expect { forge.forge }.to raise_error(ObjectInterfaceError)
+          end
+        end
+      end
+
+      describe ":attribute_list" do
+        context "when an attribute list is specified" do
+          let(:options) { { attribute_list: [:foo] } }
+
+          it "limits final attributes to those in the list but resolves using all attributes" do
+            expect(forge.forge).to eq forged_class.new(foo: 1)
+            expect(forge.forge(bar: 5)).to eq forged_class.new(foo: 1)
+            expect(forge.forge(foo: -> { bar + 3 }, bar: 5)).to eq forged_class.new(foo: 8)
+          end
+        end
+
+        context "when attribute list includes extra attributes" do
+          let(:options) { { attribute_list: %i[foo baz] } }
+
+          it "ignores the extra attributes" do
+            expect(forge.forge).to eq forged_class.new(foo: 1)
+          end
+        end
+
+        context "when attribute list reorders attributes" do
+          let(:options) do
+            { attribute_list: %i[bar foo], mold: ->(attributes:, **) { attributes.keys } }
+          end
+
+          it "passes attributes in the order specified to the mold" do
+            expect(forge.forge).to eq %i[bar foo]
+          end
+        end
+
+        context "when attribute list is empty" do
+          let(:options) { { attribute_list: [] } }
+
+          it "uses no attributes for forging" do
+            expect(forge.forge).to eq forged_class.new
+          end
+        end
+
+        context "when attribute list is nil" do
+          let(:options) { { attribute_list: nil } }
+
+          it "behaves as if no attribute list was specified" do
+            expect(forge.forge).to eq forged_class.new(foo: 1, bar: 2)
           end
         end
       end


### PR DESCRIPTION
Previously, there was no way to exclude attributes or limit final list to certain attributes. This may have been fine, depending on the mold and forge target, but generally not great. In particular, there was no way to exclude keys from a Hash. Additionally, some molds may be sensitive to attribute ordering (such as possible `ArrayMold`).

**New features:**
- Marking attributes explicitly as transient / to be excluded.
- Specifying exact attributes to be included.
- Specifying order of attributes.

**Added:**
-  `attribute_list` option to `Forge` and `ForgeDSL`.
- DSL also gets `transient` attribute metadata and `#transient` method.

**Behavior:**
- If user doesn't specify `attribute_list` or transient attributes, DSL doesn't create one.
- If user specifies transient attributes, all other attributes are automatically added to `attribute_list`.
- If both are used, `attribute_list` is checked for inclusion of transient attributes, because that would be surprising behavior either way.
- If `Forge` doesn't get an `attribute_list`, nothing is done.
- If `Forge` _does_ get an `attribute_list`, we `#slice` the resolved attributes - this both *filters* and *sorts* attributes.