### PR TITLE
Implement `yard` reference in `Crucible`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transient` keyword arguments in `ForgeDSL#attribute` and `ForgeDSL#sequence` which marks an attribute to be excluded from attribute list.
 - `#transient` method in `ForgeDSL` which is a shortcut for `attribute(name, transient: true)`.
 - `Molds::ArrayMold` that supports `Array` and subclasses.
+- `Crucible` can take a `:yard` parameter to refer to other forges in the same forgeyard.
 
 **Changed**
 - If any `transient` attributes are specified in `ForgeDSL`, an `attribute_list` will be automatically generated to exclude them.
 - `Forge` will automatically reorder attributes by `:attribute_list` if specified. Especially useful for `Molds::ArrayMold`.
 - `Molds.mold_for` will now return `Molds::ArrayMold` if relevant.
+- If `:crucible` takes a `:yard` parameter, forge's yard will be passed to it in `Forge#forge`.
 
 [Compare v0.4.1...main](https://github.com/trinistr/object_forge/compare/v0.4.1...main)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you need factory-style object generation without coupling it to Rails, Active
     - [Quick start](#quick-start)
     - [Basics](#basics)
     - [Independent forgeyards and forges](#independent-forgeyards-and-forges)
+    - [Association-like nested objects](#association-like-nested-objects)
     - [Defining final attribute list](#defining-final-attribute-list)
     - [Molds: configuring object construction](#molds-configuring-object-construction)
     - [After-build customization](#after-build-customization)
@@ -199,12 +200,15 @@ It is possible and *encouraged* to create multiple forgeyards, each with its own
 
 ```ruby
 forgeyard = ObjectForge::Forgeyard.new
+
 forgeyard.define(:dot, Point) do |f|
   f.sequence(:id, "a")
-  f.x { rand(-radius..radius) }
-  f.y { rand(-radius..radius) }
-  f.radius { 0.5 }
-  f.trait :z do f.radius { 0 } end
+  f.x { rand(-variance..variance) }
+  f.y { rand(-variance..variance) }
+
+  f.variance { 0.5 }
+
+  f.trait :z do f.variance { 0 } end
 end
 ```
 
@@ -244,6 +248,50 @@ forge.forge(:z)
 forge.(radius: 500)
   # => #<struct Point id="c", x=-141, y=109>
 ```
+
+### Association-like nested objects
+
+Nested objects can naturally be constructed in attribute definitions. However, forges belonging to forgeyards provide a more convenient way to refer to their forgeyard in attribute definitions. It is fairly simple to build object graphs by putting related forges in the same `yard`:
+
+```ruby
+geometric_yard = ObjectForge::Forgeyard.new
+geometric_yard.define(:point, Point) do |f|
+  # ... reusing the Point forge from the forgeyard example above.
+end
+
+Ellipse = Data.define(:center, :major_semiaxis, :minor_semiaxis)
+geometric_yard.define(:circle, Ellipse) do |f|
+  # Current forge's forgeyard is available as `yard` pseudo-attribute:
+  f.center { yard.forge(:point) }
+  f.transient(:radius) { 1.0 }
+
+  f.major_semiaxis { radius }
+  f.minor_semiaxis { radius }
+end
+
+geometric_yard.forge(:circle, radius: 4.0)
+  # => #<data Ellipse center=#<struct Point id="a", x=0.3487797161039954, y=-0.11378243307810132>, major_semiaxis=4.0, minor_semiaxis=4.0>
+```
+
+There is an alternative way to refer to `yard`'s forges if no attribute has the same name — just mention it by name directly:
+
+```ruby
+Line = Data.define(:a, :b)
+geometric_yard.define(:segment, Line) do |f|
+  # There is no "point" attribute, so `point` refers to the forge:
+  f.a { point.forge(:z) }
+  f.b { point.forge }
+end
+
+geometric_yard.forge(:segment)
+  # => #<data Line a=#<struct Point id="b", x=0, y=0>, b=#<struct Point id="c", x=0.2701288765117644, y=0.008413574136415414>>
+```
+
+> [!IMPORTANT]
+>
+> Referring to a related forge by name is not special syntax the same way **FactoryBot**'s _associations_ are; it just returns the forge object, which then needs to be called to construct an instance.
+
+As objects are not initialized before attributes are resolved and set, it can be tricky to create circular references. If you find yourself needing to do this, an [after-forge hook](#after-build-customization) can be used to modify objects after building them.
 
 ### Defining final attribute list
 
@@ -294,7 +342,7 @@ ObjectForge.forge(:point, position: [10, 13.4], altitude: 5, unit: :mm)
 
 > [!NOTE]
 >
-> `attribute_list` and `transient` attributes can be used in the same definition. However, transient attributes *can't* appear in attribute list; this will raise an error.
+> `attribute_list` and `transient` attributes can be used in the same definition. However, transient attributes **can't** appear in attribute list; this will raise an error.
 
 ### Molds: configuring object construction
 
@@ -395,7 +443,7 @@ Forge definition:
 
 Attributes:
 
-- *There are no associations*. If nested objects are required, they should be created and set in the block for the attribute.
+- There are no magic associations. Forgeyards provide a similar way to call related forges, but you need to be explicit about it.
 
 Traits:
 
@@ -424,8 +472,8 @@ kanban
     [Ability to replace resolver]
     [After-build hook]
     [Transient attributes / attribute filtering]
-  [⚗️ To do]
     [Reference to forgeyard in forge / crucible resolution]
+  [⚗️ To do]
     [Equality comparisons]
   [❔ Maybe, maybe not]
     [Calling traits from traits]

--- a/bin/console
+++ b/bin/console
@@ -19,11 +19,15 @@ FORGE =
     f.trait :zero do
       f.foo { 0 }
     end
+
+    f.trait :marine do
+      f.foo { sea.build }
+    end
   end
 
 FAST_FORGE =
   FORGEYARD.define(:sea, Hash) do |f|
-    f.crucible = ->(attributes) { attributes.transform_values(&:call) }
+    f.crucible = ->(attributes, **) { attributes.transform_values(&:call) }
 
     f.wide { true }
     f.deep { false }

--- a/lib/object_forge/crucible.rb
+++ b/lib/object_forge/crucible.rb
@@ -14,6 +14,8 @@ module ObjectForge
   #   and using {.call} is thread-safe.
   # @since 0.1.0
   class Crucible < UnBasicObject
+    EMPTY_YARD = {}.freeze # steep:ignore UnannotatedEmptyCollection
+
     class << self
       # Resolve all attributes by calling their +Proc+s,
       # using a new instance as evaluation context.
@@ -23,9 +25,10 @@ module ObjectForge
       # @thread_safety This method is thread-safe.
       #
       # @param attributes [Hash{Symbol => Proc, Any}] initial attributes
+      # @param yard [Hash{Symbol => Any}, nil] additional context for the crucible
       # @return [Hash{Symbol => Any}] resolved attributes
-      def call(attributes)
-        new(attributes).resolve!
+      def call(attributes, yard: EMPTY_YARD)
+        new(attributes, yard:).resolve!
       end
 
       alias resolve call
@@ -33,10 +36,15 @@ module ObjectForge
 
     %i[rand].each { |m| private define_method(m, ::Kernel.instance_method(m)) }
 
+    # @return [Hash{Symbol => Any}, Forgeyard] additional context for the crucible
+    attr_reader :yard
+
     # @param attributes [Hash{Symbol => Proc, Any}] initial attributes
-    def initialize(attributes)
+    # @param yard [Hash{Symbol => Any}, nil] additional context for the crucible
+    def initialize(attributes, yard: EMPTY_YARD)
       super()
       @attributes = attributes
+      @yard = yard || EMPTY_YARD
       @resolved_attributes = ::Set.new
       @resolving_attributes = []
     end
@@ -93,6 +101,8 @@ module ObjectForge
         raise_circular_dependency_error!(name) if @resolving_attributes.include?(name)
         resolve_attribute!(name) unless @resolved_attributes.include?(name)
         @attributes[name]
+      elsif @yard.key?(name)
+        @yard[name]
       else
         super
       end
@@ -101,7 +111,7 @@ module ObjectForge
     alias [] method_missing
 
     def respond_to_missing?(name, _include_all)
-      @attributes.key?(name) || super
+      @attributes.key?(name) || @yard.key?(name) || super
     end
 
     def raise_circular_dependency_error!(name)

--- a/lib/object_forge/forge.rb
+++ b/lib/object_forge/forge.rb
@@ -30,11 +30,11 @@ module ObjectForge
     #   A forge's options.
     #   Known options:
     #   - +:crucible+ — a +call+able object that knows how to resolve attributes,
-    #     taking a hash of initial attributes.
+    #     taking a hash of initial attributes and possibly a yard (see {Crucible}).
     #   - +:attribute_list+ — an array of attribute names to filter and sort by
     #     before passing attributes to the mold.
     #   - +:mold+ — a +call+able object that knows how to build the instance,
-    #     taking a class and a hash of attributes.
+    #     taking a class and a hash of attributes (see {Molds}).
     #   - +:after_forge+/+:after_build+ — a +call+able object that is passed
     #     the forged instance and can do anything with it.
     #   @since 0.3.0
@@ -48,15 +48,19 @@ module ObjectForge
     #
     # @param forge_target [Class, Any] class or object to forge
     # @param name [Symbol, nil] forge name
+    # @param yard [Forgeyard, nil] forgeyard this forge belongs to
     # @yieldparam dsl [ForgeDSL]
     # @yieldreturn [void]
     # @return [Forge] forge
-    def self.define(forge_target, name: nil, &)
-      new(forge_target, ForgeDSL.new(&), name:)
+    def self.define(forge_target, name: nil, yard: nil, &)
+      new(forge_target, ForgeDSL.new(&), name:, yard:)
     end
 
     # @return [Symbol, nil] forge name, only used for identification purposes
     attr_reader :name
+
+    # @return [Forgeyard, nil] forgeyard this forge belongs to
+    attr_reader :yard
 
     # @return [Class, Any] class or object to forge
     # @since 0.4.0
@@ -70,11 +74,13 @@ module ObjectForge
     #   will be passed to mold as +forge_target+ argument
     # @param parameters [Parameters, ForgeDSL] forge parameters
     # @param name [Symbol, nil] forge name
+    # @param yard [Forgeyard, nil] forgeyard this forge belongs to
     #
     # @raise [ObjectInterfaceError] if forge options do not have expected interface;
     #   see {Parameters#options} for details
-    def initialize(forge_target, parameters, name: nil)
+    def initialize(forge_target, parameters, name: nil, yard: nil)
       @name = name
+      @yard = yard
       @forge_target = forge_target
       @parameters = parameters
 
@@ -88,7 +94,6 @@ module ObjectForge
     # Forge a new instance, applying attributes to forge target.
     #
     # Positional arguments are taken as trait names, keyword arguments as attribute overrides.
-    #
     # All traits and overrides are applied in argument order,
     # with overrides always applied after traits.
     #
@@ -105,9 +110,8 @@ module ObjectForge
     #
     # @raise [ArgumentError] if a trait name is unknown
     def forge(*traits, **overrides)
-      resolved_attributes = resolve_attributes(traits, overrides)
-      resolved_attributes = apply_attribute_list(resolved_attributes)
-      instance = @mold.call(forge_target: @forge_target, attributes: resolved_attributes)
+      attributes = build_attribute_hash(traits, overrides)
+      instance = @mold.call(forge_target: @forge_target, attributes: attributes)
       @after_forge_hook&.call(instance)
       yield instance if block_given?
       instance
@@ -119,8 +123,9 @@ module ObjectForge
     private
 
     # Get a crucible object based on parameters.
-    #
     # It's either the object provided in options, or {Crucible}.
+    #
+    # This method also determines whether the crucible accepts a +yard+ parameter.
     #
     # @param options [Hash]
     # @option options [#call, nil] :crucible
@@ -130,13 +135,28 @@ module ObjectForge
     #
     # @since 0.4.0
     def determine_crucible(options)
-      crucible = options[:crucible] || Crucible
+      @crucible_takes_yard = true and return Crucible unless options[:crucible]
 
+      crucible = options[:crucible]
       unless crucible.respond_to?(:call)
         raise ObjectInterfaceError, "crucible must respond to #call"
       end
 
+      @crucible_takes_yard = crucible_takes_yard_parameter?(crucible)
       crucible
+    end
+
+    # Check if a crucible accepts a +yard+ keyword parameter.
+    #
+    # @param crucible [#call]
+    # @return [Boolean]
+    #
+    # @since <<next>>
+    def crucible_takes_yard_parameter?(crucible)
+      parameters = (Proc === crucible) ? crucible.parameters : crucible.method(:call).parameters
+      parameters.any? do |type, name|
+        type == :keyrest || ((type == :keyreq || type == :key) && name == :yard)
+      end
     end
 
     # Get appropriate mold based on parameters.
@@ -180,11 +200,33 @@ module ObjectForge
       hook
     end
 
+    # Validate options that will only be used at runtime.
+    #
+    # @param options [Hash]
+    # @option options [Array<Symbol>, nil] :attribute_list
+    #
+    # @raise [TypeError]
+    #
+    # @since <<next>>
     def validate_other_options(options)
       return if options[:attribute_list].nil?
       unless Array === options[:attribute_list] && options[:attribute_list].all? { Symbol === _1 }
         raise TypeError, "attribute_list must be an Array of Symbol"
       end
+    end
+
+    # Build final attribute hash using default attributes, specified traits and overrides,
+    # sorted and filtered by attribute list.
+    #
+    # @param traits [Array<Symbol>]
+    # @param overrides [Hash{Symbol => Proc, Any}]
+    # @return [Hash{Symbol => Any}]
+    #
+    # @raise [ArgumentError]
+    #
+    # @since <<next>>
+    def build_attribute_hash(traits, overrides)
+      apply_attribute_list(resolve_attributes(traits, overrides))
     end
 
     # Resolve attributes using default attributes, specified traits and overrides.
@@ -202,13 +244,20 @@ module ObjectForge
 
       trait_attributes = @parameters.traits.values_at(*traits) # : Array[Hash[Symbol, ObjectForge::attribute]]
       attributes = @parameters.attributes.merge(*trait_attributes, overrides)
-      @crucible.call(attributes)
+
+      if @crucible_takes_yard
+        @crucible.call(attributes, yard: @yard) # steep:ignore UnexpectedKeywordArgument
+      else
+        @crucible.call(attributes)
+      end
     end
 
     # Filter and sort attributes based on the attribute list.
     #
     # @param attributes [Hash{Symbol => Any}]
     # @return [Hash{Symbol => Any}]
+    #
+    # @since <<next>>
     def apply_attribute_list(attributes)
       return attributes unless (attribute_list = @parameters.options[:attribute_list])
 

--- a/lib/object_forge/forge_dsl.rb
+++ b/lib/object_forge/forge_dsl.rb
@@ -299,7 +299,7 @@ module ObjectForge
     # - all names ending in +?+, +!+
     # - all names starting with a non-word ASCII character
     #   (operators, +`+, +[]+, +[]=+)
-    # - +rand+
+    # - +rand+ and +yard+
     #
     # @param name [Symbol] attribute or option name
     # @param value [Any] value for option
@@ -323,7 +323,8 @@ module ObjectForge
     def respond_to_missing?(name, _include_all)
       return super if frozen?
 
-      !name.end_with?("?", "!") && !name.match?(/\A(?=\p{ASCII})\P{Word}/) && name != :rand
+      !name.end_with?("?", "!") && !name.match?(/\A(?=\p{ASCII})\P{Word}/) &&
+        !name.match?(/\A(?:rand|yard)\z/)
     end
 
     def valid_option_method?(name)

--- a/lib/object_forge/forgeyard.rb
+++ b/lib/object_forge/forgeyard.rb
@@ -27,7 +27,7 @@ module ObjectForge
     # @yieldreturn [void]
     # @return [Forge] forge
     def define(name, forge_target, &)
-      register(name, Forge.define(forge_target, name: name, &))
+      register(name, Forge.define(forge_target, name: name, yard: self, &))
     end
 
     # Add a forge under a specified name.
@@ -53,6 +53,14 @@ module ObjectForge
     # @raise [KeyError] if forge with the specified name is not registered
     def [](name)
       @forges.fetch(name)
+    end
+
+    # Check if a forge is registered under a given name.
+    #
+    # @param name [Symbol] name of the forge
+    # @return [Boolean] whether a forge is registered under the given name
+    def key?(name)
+      !!@forges.get(name)
     end
 
     # Build an instance using a forge.

--- a/lib/object_forge/molds.rb
+++ b/lib/object_forge/molds.rb
@@ -164,7 +164,7 @@ module ObjectForge
     # @thread_safety Thread-safe.
     # @since 0.3.0
     def self.wrap_mold(mold)
-      if mold.nil? || mold.respond_to?(:call)
+      if nil == mold || mold.respond_to?(:call) # rubocop:disable Style/YodaCondition
         mold # : ObjectForge::mold?
       elsif ::Class === mold && mold.public_method_defined?(:call)
         WrappedMold.new(mold)

--- a/sig/object_forge.rbs
+++ b/sig/object_forge.rbs
@@ -3,11 +3,13 @@ module ObjectForge
   type forge_result = untyped
   type attribute = untyped
 
-  type mold = ::Object & _Mold
+  type mold = _RespondTo & _Mold
+  type crucible = _RespondTo & (_Crucible | _CrucibleWithYard)
   type sequenceable = _RespondTo & _Sequenceable
 
   interface _RespondTo
     def respond_to?: (Symbol name, ?bool include_private) -> bool
+    def method: (Symbol name) -> ::Method
     def class: -> Class
   end
   interface _Sequenceable
@@ -26,9 +28,20 @@ module ObjectForge
     def call
       : (Hash[Symbol, ObjectForge::attribute]) -> Hash[Symbol, ObjectForge::attribute]
   end
+  interface _CrucibleWithYard
+    def call
+      : (Hash[Symbol, ObjectForge::attribute], ?yard: ObjectForge::_Yard?) -> Hash[Symbol, ObjectForge::attribute]
+  end
   interface _Hook
     def call
       : (ObjectForge::forge_result) -> void
+  end
+  interface _Yard
+    def []
+      : (Symbol name) -> untyped
+    
+    def key?
+      : (Symbol name) -> bool
   end
 
   class Error < StandardError
@@ -87,6 +100,9 @@ class ObjectForge::Forgeyard
   
   def []
     : (Symbol name) -> ObjectForge::Forge
+  
+  def key?
+    : (Symbol name) -> bool
 
   def forge
     : (Symbol name, *Symbol traits, **ObjectForge::attribute overrides) ?{ (ObjectForge::forge_result) -> void } -> ObjectForge::forge_result
@@ -103,23 +119,25 @@ class ObjectForge::Forge
       : (attributes: Hash[Symbol, ObjectForge::attribute], traits: Hash[Symbol, Hash[Symbol, ObjectForge::attribute]], options: Hash[Symbol, untyped]) -> void
   end
 
+  attr_reader name: Symbol?
+
+  attr_reader yard: ObjectForge::_Yard?
+
   attr_reader forge_target: ObjectForge::forge_target
   alias target forge_target
 
-  attr_reader name: Symbol?
-
   attr_reader parameters: ObjectForge::_ForgeParameters
 
-  @crucible: ObjectForge::_Crucible
+  @crucible: ObjectForge::crucible
   @mold: ObjectForge::_Mold
   @after_forge_hook: ObjectForge::_Hook?
 
   def self.define
-    : (ObjectForge::forge_target, ?name: Symbol?) { (ObjectForge::ForgeDSL) -> void } -> ObjectForge::Forge
-    | (ObjectForge::forge_target, ?name: Symbol?) { [self: ObjectForge::ForgeDSL] -> void } -> ObjectForge::Forge
+    : (ObjectForge::forge_target, ?name: Symbol?, ?yard: ObjectForge::_Yard?) { (ObjectForge::ForgeDSL) -> void } -> ObjectForge::Forge
+    | (ObjectForge::forge_target, ?name: Symbol?, ?yard: ObjectForge::_Yard?) { [self: ObjectForge::ForgeDSL] -> void } -> ObjectForge::Forge
   
   def initialize
-    : (ObjectForge::forge_target, ObjectForge::_ForgeParameters parameters, ?name: Symbol?) -> void
+    : (ObjectForge::forge_target, ObjectForge::_ForgeParameters parameters, ?name: Symbol?, ?yard: ObjectForge::_Yard?) -> void
   
   def forge
     : (*Symbol traits, **ObjectForge::attribute overrides) ?{ (ObjectForge::forge_result) -> void } -> ObjectForge::forge_result
@@ -129,7 +147,10 @@ class ObjectForge::Forge
   private
   
   def determine_crucible
-    : (Hash[Symbol, untyped]) -> ObjectForge::_Crucible
+    : (Hash[Symbol, untyped]) -> ObjectForge::crucible
+
+  def crucible_takes_yard_parameter?
+    : (ObjectForge::crucible) -> bool
 
   def determine_mold
     : (ObjectForge::forge_target, Hash[Symbol, untyped]) -> ObjectForge::mold
@@ -139,6 +160,9 @@ class ObjectForge::Forge
   
   def validate_other_options
     : (Hash[Symbol, untyped] options) -> void
+
+  def build_attribute_hash
+    : (Array[Symbol] traits, Hash[Symbol, ObjectForge::attribute] overrides) -> Hash[Symbol, ObjectForge::attribute]
 
   def resolve_attributes
     : (Array[Symbol] traits, Hash[Symbol, ObjectForge::attribute] overrides) -> Hash[Symbol, ObjectForge::attribute]
@@ -204,17 +228,21 @@ class ObjectForge::ForgeDSL < ObjectForge::UnBasicObject
 end
 
 class ObjectForge::Crucible < ObjectForge::UnBasicObject
+  EMPTY_YARD: Hash[Symbol, untyped]
+
   def self.call
-    : (Hash[Symbol, ObjectForge::attribute]) -> Hash[Symbol, ObjectForge::attribute]
+    : (Hash[Symbol, ObjectForge::attribute], ?yard: ObjectForge::_Yard?) -> Hash[Symbol, ObjectForge::attribute]
   def self.resolve
-    : (Hash[Symbol, ObjectForge::attribute]) -> Hash[Symbol, ObjectForge::attribute]
+    : (Hash[Symbol, ObjectForge::attribute], ?yard: ObjectForge::_Yard?) -> Hash[Symbol, ObjectForge::attribute]
 
   @attributes: Hash[Symbol, ObjectForge::attribute]
   @resolved_attributes: Set[Symbol]
   @resolving_attributes: Array[Symbol]
 
+  attr_reader yard: ObjectForge::_Yard
+
   def initialize
-    : (Hash[Symbol, ObjectForge::attribute] attributes) -> void
+    : (Hash[Symbol, ObjectForge::attribute] attributes, ?yard: ObjectForge::_Yard?) -> void
 
   def resolve!
     : -> Hash[Symbol, ObjectForge::attribute]

--- a/spec/object_forge/crucible_spec.rb
+++ b/spec/object_forge/crucible_spec.rb
@@ -2,9 +2,10 @@
 
 module ObjectForge
   RSpec.describe Crucible do
-    subject(:crucible) { described_class.new(attributes) }
+    subject(:crucible) { described_class.new(attributes, yard:) }
 
     let(:attributes) { { foo: -> { 1 }, bar: 2, baz: -> { foo + bar } } }
+    let(:yard) { { special: 33 } }
 
     describe ".call" do
       subject(:resolved_attributes) { described_class.call(attributes) }
@@ -23,10 +24,22 @@ module ObjectForge
 
         expect(resolved_attributes).to eq({ success: true })
       end
+
+      it "passes yard along" do
+        expect(described_class.call({ a: -> { b } }, yard: { b: :bee })).to eq({ a: :bee })
+      end
     end
 
     describe described_class.singleton_class do
       include_examples "has an alias", :resolve, :call
+    end
+
+    describe "#yard" do
+      let(:yard) { { foo: 1, bar: 2 } }
+
+      it "returns the yard" do
+        expect(crucible.yard).to be yard
+      end
     end
 
     describe "#resolve!" do
@@ -64,12 +77,30 @@ module ObjectForge
       context "if an attribute is not found" do
         let(:attributes) { { foo: -> { 1 }, bar: 2, baz: -> { foo + bard } } }
 
-        it "raises NameError" do
-          expect { crucible.resolve! }.to raise_error(
-            NameError,
-            # Ruby 3.4 changed initial quote from "`" to "'" in error messages.
-            /\Aundefined local variable or method ['`]bard'/
-          )
+        context "and yard does not contain the missing name" do
+          it "raises NameError" do
+            expect { crucible.resolve! }.to raise_error(
+              NameError,
+              # Ruby 3.4 changed initial quote from "`" to "'" in error messages.
+              /\Aundefined local variable or method ['`]bard'/
+            )
+          end
+        end
+
+        context "and yard contains the missing name" do
+          let(:yard) { { bard: 6 } }
+
+          it "uses value rom the yard instead of raising" do
+            expect(crucible.resolve!).to eq({ foo: 1, bar: 2, baz: 7 })
+          end
+        end
+      end
+
+      context "if attributes and yard have the same key" do
+        let(:yard) { { foo: 99 } }
+
+        it "uses value from attributes" do
+          expect(crucible.resolve!).to eq({ foo: 1, bar: 2, baz: 3 })
         end
       end
 
@@ -159,10 +190,16 @@ module ObjectForge
     end
 
     describe "#respond_to?" do
-      it "returns true if a corresponding key exists" do
+      it "returns true if a corresponding key exists in attributes" do
         key = attributes.keys.sample
         expect(crucible).to respond_to key
         expect(crucible.__send__(key)).to be attributes[key]
+      end
+
+      it "returns true if a corresponding key exists in yard" do
+        key = yard.keys.sample
+        expect(crucible).to respond_to key
+        expect(crucible.__send__(key)).to be yard[key]
       end
 
       it "returns false if a corresponding key does not exist" do

--- a/spec/object_forge/forge_dsl_spec.rb
+++ b/spec/object_forge/forge_dsl_spec.rb
@@ -503,7 +503,9 @@ module ObjectForge
 
       context "when called with a reserved name" do
         %i[
-          name? name! ` []= + - * / % ** +@ -@ & | ^ ~ @~ << >> < > <= >= === !== =~ !~ rand
+          name? name!
+          ` []= + - * / % ** +@ -@ & | ^ ~ @~ << >> < > <= >= === !== =~ !~
+          rand yard
         ].each do |reserved_name|
           describe "##{reserved_name}" do
             let(:definition) { proc { |f| f.__send__(reserved_name) { "Name?" } } }
@@ -554,7 +556,9 @@ module ObjectForge
 
         context "when called with a reserved name" do
           %i[
-            name? name! ` []= + - * / % ** +@ -@ & | ^ ~ @~ << >> < > <= >= === !== =~ !~ rand
+            name? name!
+            ` []= + - * / % ** +@ -@ & | ^ ~ @~ << >> < > <= >= === !== =~ !~
+            rand yard
           ].each do |reserved_name|
             describe "##{reserved_name}" do
               let(:name) { reserved_name }

--- a/spec/object_forge/forge_spec.rb
+++ b/spec/object_forge/forge_spec.rb
@@ -2,10 +2,11 @@
 
 module ObjectForge
   RSpec.describe Forge do
-    subject(:forge) { described_class.new(forged_class, parameters, name: name) }
+    subject(:forge) { described_class.new(forged_class, parameters, name: name, yard: yard) }
 
     let(:forged_class) { Struct.new(:foo, :bar, keyword_init: true) }
     let(:name) { "ASDFg" }
+    let(:yard) { { bar: 3 } }
     let(:parameters) do
       described_class::Parameters.new(
         options: options,
@@ -17,6 +18,36 @@ module ObjectForge
     end
     let(:options) { {} }
 
+    describe "#name" do
+      it "returns the specified name of the forge" do
+        expect(forge.name).to eq name
+      end
+
+      context "when name is nil" do
+        let(:name) { nil }
+
+        it "returns nil" do
+          expect(forge.name).to be nil
+        end
+      end
+    end
+
+    describe "#yard" do
+      let(:yard) { instance_double(Forgeyard) }
+
+      it "returns the specified yard of the forge" do
+        expect(forge.yard).to be yard
+      end
+
+      context "when yard is nil" do
+        let(:yard) { nil }
+
+        it "returns nil" do
+          expect(forge.yard).to be nil
+        end
+      end
+    end
+
     describe "#forge_target" do
       it "returns the class to forge" do
         expect(forge.forge_target).to be forged_class
@@ -27,12 +58,6 @@ module ObjectForge
     describe "#target" do
       it "returns the class to forge" do
         expect(forge.target).to be forged_class
-      end
-    end
-
-    describe "#name" do
-      it "returns the name of the forge" do
-        expect(forge.name).to eq name
       end
     end
 
@@ -152,11 +177,40 @@ module ObjectForge
       end
 
       describe ":crucible" do
-        context "with a non-nil object" do
-          let(:options) { { crucible: ->(attributes) { attributes.transform_values(&:inspect) } } }
+        context "with a non-nil object taking only attributes" do
+          let(:options) do
+            { crucible: ->(attributes) { attributes.transform_values(&:inspect) } }
+          end
 
           it "uses the object to resolve attributes" do
             expect(forge.forge).to have_attributes(foo: /Proc/, bar: /Proc/)
+          end
+        end
+
+        context "with a non-nil object taking attributes and :yard keyword parameter" do
+          let(:crucible) do
+            Class.new do
+              def call(attributes, yard: {})
+                attributes.to_h { |k, v| [k, yard[k] || v.inspect] }
+              end
+            end
+          end
+          let(:options) { { crucible: crucible.new } }
+
+          it "uses the object to resolve attributes" do
+            expect(forge.forge).to have_attributes(foo: /Proc/, bar: 3)
+          end
+
+          context "if crucible takes :yard in keyrest parameters" do
+            let(:options) do
+              { crucible: ->(attributes, **kwargs) {
+                attributes.to_h { |k, v| [k, kwargs[:yard][k] || v.inspect] }
+              } }
+            end
+
+            it "detects that and supplies the yard" do
+              expect(forge.forge).to have_attributes(foo: /Proc/, bar: 3)
+            end
           end
         end
 

--- a/spec/object_forge/forgeyard_spec.rb
+++ b/spec/object_forge/forgeyard_spec.rb
@@ -29,7 +29,7 @@ module ObjectForge
 
       it "defines and registers a forge" do
         expect { definition }.to change(forgeyard.forges, :size).by(1)
-        expect(Forge).to have_received(:define).with(Object, name: :foo)
+        expect(Forge).to have_received(:define).with(Object, name: :foo, yard: forgeyard)
         expect(forgeyard.forges[:foo]).to be forge
       end
     end
@@ -77,6 +77,18 @@ module ObjectForge
         it "raises KeyError" do
           expect { forgeyard[:nonexistent] }.to raise_error KeyError
         end
+      end
+    end
+
+    describe "key?" do
+      before { forgeyard.register(:test, forge) }
+
+      it "returns true if a forge is registered under the given name" do
+        expect(forgeyard.key?(:test)).to be true
+      end
+
+      it "returns false if a forge is not registered under the given name" do
+        expect(forgeyard.key?(:nonexistent)).to be false
       end
     end
 


### PR DESCRIPTION
Forgeyards were always intended to provide association-like behavior for forging, not just a container that is easily replaced with a hash. This is implemented now through a cross-cutting change:
- `Forge` remembers the `Forgeyard` it is registered in.
- If crucible takes a `:yard` argument, forge will pass the forgeyard for context.
- `Crucible` has such a parameter and will use it to resolve other forges.
- `yard` is now a reserved name in `ForgeDSL`.